### PR TITLE
Fix: Increase vertical padding to resolve title overlap

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -1,7 +1,7 @@
 const styles = {
     paddingX: "sm:px-16 px-6",
     paddingY: "sm:py-16 py-6",
-    padding: "sm:px-16 px-6 sm:py-16 py-10",
+    padding: "sm:px-16 px-6 sm:py-20 py-16",
   
     heroHeadText:
       "font-black text-white lg:text-[80px] sm:text-[60px] xs:text-[50px] text-[40px] lg:leading-[98px] mt-2",


### PR DESCRIPTION
I increased vertical padding in sections by modifying styles.padding in src/styles.js from "sm:px-16 px-6 sm:py-16 py-10" to "sm:px-16 px-6 sm:py-20 py-16".

This change provides more space between the "Works" section (Projects) and the "Experience" section, resolving an issue where the "Experience and Education" title would overlap with the project cards. The overlap was caused by a combination of existing section padding and a negative top margin on a hash-span element used for anchor link offsetting.